### PR TITLE
s3wrapper-3 FileWrapper file URI only works when S3 client is not null

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>au.gov.aims</groupId>
     <artifactId>s3wrapper</artifactId>
-    <version>0.3.24</version>
+    <version>0.3.25</version>
     <packaging>jar</packaging>
     <name>S3 Wrapper</name>
     <description>S3 Wrapper made to simplify the Amazon S3 API.</description>


### PR DESCRIPTION
Issue #3 v0.3.25
- Add "file://" protocol to FileWrapper URI when no protocol is provided
- Only require client to not be null when dealing with S3 URI.